### PR TITLE
Call `super` in `method_added` hook.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 *.a
 mkmf.log
 *.gem
+.ruby-version
+.ruby-gemset
+.rvmrc

--- a/lib/method_hooks.rb
+++ b/lib/method_hooks.rb
@@ -10,6 +10,7 @@ module MethodHooks
   private
 
   def method_added(method_name)
+    super
     return if @new_method == false || [:initialize, :call_before_callbacks, :call_around_callbacks, :call_after_callbacks].include?(method_name)
 
     method = instance_method(method_name)

--- a/spec/lib/method_hooks_spec.rb
+++ b/spec/lib/method_hooks_spec.rb
@@ -5,7 +5,20 @@ describe MethodHooks do
   before do
     Object.send(:remove_const, :Base) if Object.const_defined?(:Base)
 
+    module AnotherModuleWIthMethodAddedHook
+      def method_added(method_name)
+        _methods << method_name
+        super
+      end
+
+      def _methods
+        @_methods ||= []
+      end
+    end
+
     class Base
+
+      extend AnotherModuleWIthMethodAddedHook
       extend MethodHooks
 
       attr_reader :events
@@ -79,6 +92,15 @@ describe MethodHooks do
       expect(base.events).to eq(['save', 'after'])
     end
 
+  end
+
+  it 'does not override existing .method_added hook' do
+    Base.class_eval do
+      def some_method
+      end
+    end
+
+    expect(Base._methods).to include(:some_method)
   end
 
 end


### PR DESCRIPTION
There was a little bug when you already have a `method_added` hook that was defined in the module that was included before `MethodHooks` module. This patch avoids possible conflicts with other libraries. Check specs for an example.