### PR TITLE
Added support for newer gems

### DIFF
--- a/method_hooks.gemspec
+++ b/method_hooks.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.2.0"
+  spec.add_development_dependency "bundler", ">= 1.7"
+  spec.add_development_dependency "rake", ">= 10.0"
+  spec.add_development_dependency "rspec", ">= 3.2.0"
 
-  spec.add_dependency "activesupport", "~> 4.1"
+  spec.add_dependency "activesupport", ">= 4.1"
 end


### PR DESCRIPTION
Right now, the gem's `gempsec` uses `~>`, which locks every user to use old and unmaintained versions of popular gems (e.g. requires `ActiveSupport` around `4.1`, while it is currently stable at `6.1.4`). 

This PR changes it to `>=` so that it keeps a baseline for support but allows for newer versions of the gems to be used.

The problem arose when trying to use the gem in a test suite, and it overwrote all version of ActiveRecord, ActiveModel and ActiveSupport to `4.1` (oldest supported version is 5.2).